### PR TITLE
Custom MCX set Org to Hiera lookup first

### DIFF
--- a/manifests/mcx.pp
+++ b/manifests/mcx.pp
@@ -127,13 +127,15 @@ ${bluetooth}",
     true    => absent,
     default => present,
   }
+  
+  $organization = hiera('managedmac::organization', 'Simon Fraser University')
 
   mobileconfig { 'managedmac.mcx.alacarte':
     ensure            => $ensure,
     content           => $content,
     description       => 'Custom MCX Settings',
     displayname       => 'Managed Mac: Custom MCX',
-    organization      => 'Simon Fraser University',
+    organization      => $organization,
     removaldisallowed => false,
   }
 


### PR DESCRIPTION
Sets the organization for custom mcx profiles to the hiera data firstly then defaults back to Simon Fraser University if needed.