### PR TITLE
Revert delint: c5ecc6ebab9fdbd22ad229248b368de0d8ec7ccb

### DIFF
--- a/manifests/portablehomes.pp
+++ b/manifests/portablehomes.pp
@@ -476,10 +476,10 @@ class managedmac::portablehomes (
   $enable_re_values = ['^true$', '^false$', '^10\.\d{1,2}\.?\d{0,2}$',]
 
   # Validate $enable as a string
-  validate_re ($enable, $enable_re_values)
+  validate_re ("${enable}", $enable_re_values)
 
   # Evaluate $enable as an OS X major version string and deduce a state
-  $os_conditional = versioncmp($enable, $::macosx_productversion_major) ? {
+  $os_conditional = versioncmp("${enable}", $::macosx_productversion_major) ? {
     0       => present,
     default => absent,
   }


### PR DESCRIPTION
I recommend reverting commit c5ecc6ebab9fdbd22ad229248b368de0d8ec7ccb. Not sure what you were trying to accomplish with cleaning up the code here so feel free to revisit the change yourself or revert the code with this pull request. In the latest branch of 0.6.0 I am seeing the following:

```bash
error
Error: validate_re(): false does not match ["^true$", "^false$", "^10\\.\\d{1,2}\\.?\\d{0,2}$"] at /etc/puppet/environments/production/modules/managedmac/manifests/portablehomes.pp:479 on node 011-adm-maccb.example.com
Error: validate_re(): false does not match ["^true$", "^false$", "^10\\.\\d{1,2}\\.?\\d{0,2}$"] at /etc/puppet/environments/production/modules/managedmac/manifests/portablehomes.pp:479 on node 011-adm-maccb.example.com
````