### PR TITLE
allow standard users to restart/shutdown

### DIFF
--- a/files/sample.yaml
+++ b/files/sample.yaml
@@ -734,12 +734,30 @@ managedmac::authorization::allow_timemachine: true
 managedmac::authorization::allow_printers: true
 
 #####################################################################
-# Allow 'everyone' to set the inital DVD region code.
+# Allow 'everyone' to set the initial DVD region code.
 # Default: false
 # Type: Boolean
 #####################################################################
 
 managedmac::authorization::allow_dvd_setregion_initial: true
+
+#####################################################################
+# Allow 'everyone' to restart the system while other users are 
+# logged onto the system.
+# Default: false
+# Type: Boolean
+#####################################################################
+
+managedmac::authorization::allow_restart: true
+
+#####################################################################
+# Allow 'everyone' to shutdown the system while other users are 
+# logged onto the system.
+# Default: false
+# Type: Boolean
+#####################################################################
+
+managedmac::authorization::allow_shutdown: true
 
 #####################################################################
 #

--- a/manifests/authorization.pp
+++ b/manifests/authorization.pp
@@ -26,7 +26,19 @@
 #   Type: Bool
 #
 # [*allow_dvd_setregion_initial*]
-#   Allow 'everyone' to set the inital DVD region code, true or false.
+#   Allow 'everyone' to set the initial DVD region code, true or false.
+#   Default: false
+#   Type: Bool
+#
+# [*allow_restart*]
+#   Allow 'everyone' to restart the system while other users are logged
+#   onto the system, true or false.
+#   Default: false
+#   Type: Bool
+#
+# [*allow_shutdown*]
+#   Allow 'everyone' to shutdown the system while other users are logged
+#   onto the system, true or false.
 #   Default: false
 #   Type: Bool
 #
@@ -74,6 +86,8 @@ class managedmac::authorization (
   $allow_timemachine            = false,
   $allow_printers               = false,
   $allow_dvd_setregion_initial  = false,
+  $allow_restart                = false,
+  $allow_shutdown               = false,
 
 ) {
 
@@ -85,6 +99,8 @@ class managedmac::authorization (
 
   # Other options
   validate_bool ($allow_dvd_setregion_initial)
+  validate_bool ($allow_restart)
+  validate_bool ($allow_shutdown)
 
   # Getting System Preference panes unlocked for non-admins requires us to
   # first change the parent right 'system.preferences'. To know whether or not
@@ -92,7 +108,7 @@ class managedmac::authorization (
   # into Integers, add them up, and if the $sum is greater than zero, the
   # 'system.preferences' right is changed to 'everyone' to match the others.
   #
-  # If you are adding new controls fro System Preferences panes, be sure and
+  # If you are adding new controls from System Preferences panes, be sure and
   # include the new bool value in this calculation.
   #
   $sum = (bool2num($allow_energysaver) + bool2num($allow_datetime) +
@@ -157,6 +173,24 @@ Printing preference pane.",
 time.  Note that changing the region code after it has been set requires a \
 different right (system.device.dvd.setregion.change).",
     },
+    
+    'system.restart' => {
+      group      => $allow_restart ? {
+        true    => 'everyone',
+        default => 'admin',
+      },
+      comment => "Checked by the Admin framework when attempting to \
+restart a system.",
+    },    
+    
+    'system.shutdown' => {
+      group      => $allow_shutdown ? {
+        true    => 'everyone',
+        default => 'admin',
+      },
+      comment => "Checked by the Admin framework when attempting to \
+shutdown a system.",
+    },    
 
   }
 

--- a/spec/classes/managedmac_authorization_spec.rb
+++ b/spec/classes/managedmac_authorization_spec.rb
@@ -149,4 +149,52 @@ describe "managedmac::authorization", :type => 'class' do
     end
   end
 
+  context "when $allow_restart == true" do
+    let(:params) do
+      { :allow_energysaver => false,
+        :allow_datetime => false,
+        :allow_restart => true,
+      }
+    end
+
+    it do
+      should contain_macauthdb('system.preferences.energysaver').with(
+        'group' => 'admin',)
+    end
+
+    it do
+      should contain_macauthdb('system.preferences.datetime').with(
+        'group' => 'admin',)
+    end
+
+    it do
+      should contain_macauthdb('system.restart').with(
+        'group' => 'everyone',)
+    end
+  end
+
+  context "when $allow_shutdown == true" do
+    let(:params) do
+      { :allow_energysaver => false,
+        :allow_datetime => false,
+        :allow_shutdown => true,
+      }
+    end
+
+    it do
+      should contain_macauthdb('system.preferences.energysaver').with(
+        'group' => 'admin',)
+    end
+
+    it do
+      should contain_macauthdb('system.preferences.datetime').with(
+        'group' => 'admin',)
+    end
+
+    it do
+      should contain_macauthdb('system.shutdown').with(
+        'group' => 'everyone',)
+    end
+  end
+
 end


### PR DESCRIPTION
This allows standard users to restart and/or shutdown the computer while other users are logged on (including at the login window). Doing so normally requires an administrator password. This is great in lab environments when students might forget to logout of the system.

Please check the spec.rb file still learning and not 100% sure I get the logic, I just copies and pasted from other parameters.

Additionally, fixes two typos related to the auth files. (initial, & from)